### PR TITLE
Add FreeBSD VM setup script and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# FreeBSD Development Environment
+
+This repository provides a script to launch a FreeBSD 14.3-RELEASE virtual machine
+inside the codex environment. The VM uses the official cloud image and is
+configured with `cloud-init` for a ready-to-use `codex` user.
+
+## Usage
+
+1. Run `./freebsd-setup.sh`.
+2. Once booted, connect via `ssh codex@localhost -p 2222` (password `codex`).
+3. Shutdown the VM with `sudo shutdown -p now` inside the guest.
+
+## Details
+
+- Image: `FreeBSD-14.3-RELEASE-amd64-BASIC-CLOUDINIT-ufs.qcow2`
+- The script installs required packages (`qemu-system-x86`, `qemu-utils`,
+  `cloud-image-utils`, `xz-utils`) if missing.
+- SSH is forwarded to host port `2222`.
+- The `codex` user is in the `wheel` group with passwordless `sudo`.
+
+This setup allows future tasks to run in a FreeBSD environment while still
+working from the existing codex container.

--- a/freebsd-setup.sh
+++ b/freebsd-setup.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Setup and launch a FreeBSD 14.3-RELEASE virtual machine using QEMU.
+# The VM exposes SSH on localhost:2222 with user 'codex'/'codex'.
+
+set -euo pipefail
+
+FREEBSD_VERSION="14.3-RELEASE"
+IMAGE_NAME="FreeBSD-${FREEBSD_VERSION}-amd64-BASIC-CLOUDINIT-ufs.qcow2"
+IMAGE_URL="https://download.freebsd.org/releases/VM-IMAGES/${FREEBSD_VERSION}/amd64/Latest/${IMAGE_NAME}.xz"
+
+# Ensure required packages are present
+if ! command -v qemu-system-x86_64 >/dev/null 2>&1; then
+  echo "Installing qemu-system-x86, qemu-utils and cloud-image-utils"
+  apt-get update
+  apt-get install -y qemu-system-x86 qemu-utils cloud-image-utils xz-utils
+fi
+
+# Download and decompress the FreeBSD image if needed
+if [ ! -f "${IMAGE_NAME}" ]; then
+  echo "Downloading FreeBSD image ${IMAGE_NAME}"
+  curl -L -o "${IMAGE_NAME}.xz" "${IMAGE_URL}"
+  unxz "${IMAGE_NAME}.xz"
+fi
+
+# Create cloud-init user-data image
+if [ ! -f user-data.img ]; then
+  cat > user-data <<'CLOUD'
+#cloud-config
+password: codex
+chpasswd: { expire: False }
+ssh_pwauth: True
+users:
+  - name: codex
+    gecos: Codex User
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    shell: /bin/sh
+    groups: wheel
+CLOUD
+  cloud-localds user-data.img user-data
+fi
+
+# Launch the VM
+qemu-system-x86_64 \
+  -m 2048 \
+  -smp 2 \
+  -drive if=virtio,file="${IMAGE_NAME}",format=qcow2 \
+  -drive if=virtio,file=user-data.img,format=raw \
+  -nic user,model=virtio-net-pci,hostfwd=tcp::2222-:22 \
+  -nographic


### PR DESCRIPTION
## Summary
- add `freebsd-setup.sh` script to download and run a FreeBSD 14.3-RELEASE VM via QEMU
- document usage and VM details in new `README.md`

## Testing
- `bash -n freebsd-setup.sh`


------
https://chatgpt.com/codex/tasks/task_e_6895e52b5ef88322bb17c973b789cb5e