### PR TITLE
Add FreeBSD VM setup script and documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,15 @@
+# Agent Instructions
+
+This repository uses a FreeBSD virtual machine for development and testing.
+
+## Running the VM
+- Start the VM in a separate terminal with `./freebsd-setup.sh`.
+
+## Running commands and tests
+- Execute commands inside the VM using `./freebsd-run.sh <command>`.
+- When editing code meant for the VM, run checks through `./freebsd-run.sh` (e.g., `./freebsd-run.sh make test` or `./freebsd-run.sh sh -n script.sh`).
+
+## Host scripts
+- Host-side helper scripts like `freebsd-setup.sh` and `freebsd-run.sh` should be linted on the host with:
+  - `bash -n freebsd-setup.sh`
+  - `sh -n freebsd-run.sh`

--- a/README.md
+++ b/README.md
@@ -1,21 +1,25 @@
-# FreeBSD Development Environment
+# test-codex
 
-This repository provides a script to launch a FreeBSD 14.3-RELEASE virtual machine
-inside the codex environment. The VM uses the official cloud image and is
-configured with `cloud-init` for a ready-to-use `codex` user.
+This repository contains simple shell scripts and helpers for running tests.
 
-## Usage
+## FreeBSD Development Environment
+
+We provide a script to launch a FreeBSD 14.3-RELEASE virtual machine inside the
+codex environment. The VM uses the official cloud image and is configured with
+`cloud-init` for a ready-to-use `codex` user.
+
+### Usage
 
 1. Run `./freebsd-setup.sh` in its own terminal to boot the VM.
 2. In another terminal, run `./freebsd-run.sh` for an interactive shell or append a
    command, e.g. `./freebsd-run.sh uname -a`.
 3. Transfer files as needed using `scp -P 2222 <path> codex@localhost:`.
-4. Shutdown the VM with `sudo shutdown -p now` inside the guest.
+4. Shut down the VM with `sudo shutdown -p now` inside the guest.
 
-## Details
+### Details
 
 - Image: `FreeBSD-14.3-RELEASE-amd64-BASIC-CLOUDINIT-ufs.qcow2`
-- The script installs required packages (`qemu-system-x86`, `qemu-utils`,
+- The setup script installs required packages (`qemu-system-x86`, `qemu-utils`,
   `cloud-image-utils`, `xz-utils`) if missing.
 - SSH is forwarded to host port `2222`.
 - The `codex` user is in the `wheel` group with passwordless `sudo`.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This repository contains simple shell scripts and helpers for running tests.
 
+## Running tests
+
+Run `./all.sh` directly or invoke `make` to execute the default test script.
+
 ## FreeBSD Development Environment
 
 We provide a script to launch a FreeBSD 14.3-RELEASE virtual machine inside the

--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+# FreeBSD Development Environment
+
+This repository provides a script to launch a FreeBSD 14.3-RELEASE virtual machine
+inside the codex environment. The VM uses the official cloud image and is
+configured with `cloud-init` for a ready-to-use `codex` user.
+
+## Usage
+
+1. Run `./freebsd-setup.sh` in its own terminal to boot the VM.
+2. In another terminal, run `./freebsd-run.sh` for an interactive shell or append a
+   command, e.g. `./freebsd-run.sh uname -a`.
+3. Transfer files as needed using `scp -P 2222 <path> codex@localhost:`.
+4. Shutdown the VM with `sudo shutdown -p now` inside the guest.
+
+## Details
+
+- Image: `FreeBSD-14.3-RELEASE-amd64-BASIC-CLOUDINIT-ufs.qcow2`
+- The script installs required packages (`qemu-system-x86`, `qemu-utils`,
+  `cloud-image-utils`, `xz-utils`) if missing.
+- SSH is forwarded to host port `2222`.
+- The `codex` user is in the `wheel` group with passwordless `sudo`.
+
+This setup allows future tasks to run in a FreeBSD environment while still
+working from the existing codex container.

--- a/freebsd-run.sh
+++ b/freebsd-run.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env sh
+# Helper script to run commands inside the FreeBSD VM.
+# If no arguments are provided, an interactive shell is opened.
+
+PORT=2222
+
+if [ $# -eq 0 ]; then
+  exec ssh -o StrictHostKeyChecking=no -p "$PORT" codex@localhost
+else
+  exec ssh -o StrictHostKeyChecking=no -p "$PORT" codex@localhost "$@"
+fi

--- a/freebsd-setup.sh
+++ b/freebsd-setup.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Setup and launch a FreeBSD 14.3-RELEASE virtual machine using QEMU.
+# The VM exposes SSH on localhost:2222 with user 'codex'/'codex'.
+
+set -euo pipefail
+
+FREEBSD_VERSION="14.3-RELEASE"
+IMAGE_NAME="FreeBSD-${FREEBSD_VERSION}-amd64-BASIC-CLOUDINIT-ufs.qcow2"
+IMAGE_URL="https://download.freebsd.org/releases/VM-IMAGES/${FREEBSD_VERSION}/amd64/Latest/${IMAGE_NAME}.xz"
+
+# Ensure required packages are present
+if ! command -v qemu-system-x86_64 >/dev/null 2>&1; then
+  echo "Installing qemu-system-x86, qemu-utils and cloud-image-utils"
+  apt-get update
+  apt-get install -y qemu-system-x86 qemu-utils cloud-image-utils xz-utils
+fi
+
+# Download and decompress the FreeBSD image if needed
+if [ ! -f "${IMAGE_NAME}" ]; then
+  echo "Downloading FreeBSD image ${IMAGE_NAME}"
+  curl -L -o "${IMAGE_NAME}.xz" "${IMAGE_URL}"
+  unxz "${IMAGE_NAME}.xz"
+fi
+
+# Create cloud-init user-data image
+if [ ! -f user-data.img ]; then
+  cat > user-data <<'CLOUD'
+#cloud-config
+password: codex
+chpasswd: { expire: False }
+ssh_pwauth: True
+users:
+  - name: codex
+    gecos: Codex User
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    shell: /bin/sh
+    groups: wheel
+CLOUD
+  cloud-localds user-data.img user-data
+fi
+
+# Launch the VM
+qemu-system-x86_64 \
+  -m 2048 \
+  -smp 2 \
+  -drive if=virtio,file="${IMAGE_NAME}",format=qcow2 \
+  -drive if=virtio,file=user-data.img,format=raw \
+  -nic user,model=virtio-net-pci,hostfwd=tcp::2222-:22 \
+  -nographic


### PR DESCRIPTION
## Summary
- add `freebsd-setup.sh` script to download and run a FreeBSD 14.3-RELEASE VM via QEMU
- document usage and VM details in new `README.md`
- add `freebsd-run.sh` helper for running commands inside the VM and expand README usage instructions
- add `AGENTS.md` with guidance on running checks within the FreeBSD VM

## Testing
- `bash -n freebsd-setup.sh`
- `sh -n freebsd-run.sh`


------
https://chatgpt.com/codex/tasks/task_e_6895e52b5ef88322bb17c973b789cb5e